### PR TITLE
Fixing outages parser to include prefecture extraction.

### DIFF
--- a/Client/lib/models/OutageDto.dart
+++ b/Client/lib/models/OutageDto.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 /// Representational model of an outage as presented from DEDDHE.
 /// Note: Any additions to the fields of this class must result to additions on the constructor and the factory
 /// constructor.
-class Outage{
+class OutageDto{
   String prefecture = "";
   String fromDatetime = "";
   String toDatetime = "";
@@ -11,10 +11,10 @@ class Outage{
   String areaDescription = "";
   String number = "";
   String reason = "";
-  List<Outage> outages = [];
+  List<OutageDto> outages = [];
 
   ///Constructor that *must* set all the fields of the Outage model.
-  Outage(String prefecture, String fromDatetime, String toDatetime, String municipality,
+  OutageDto(String prefecture, String fromDatetime, String toDatetime, String municipality,
       String areaDescription, String number, String reason){
     this.prefecture = prefecture;
     this.fromDatetime = fromDatetime;
@@ -27,14 +27,14 @@ class Outage{
 
   ///Factory constructor that initializes a final variable from a json object.
   ///This is used to instantly create an Outage object from the respective REST response.
-  factory Outage.fromJson(Map<String, dynamic> json){
-    return Outage(json['prefecture'] as String, json['from_datetime'] as String,
+  factory OutageDto.fromJson(Map<String, dynamic> json){
+    return OutageDto(json['prefecture'] as String, json['from_datetime'] as String,
         json['to_datetime'] as String, json['municipality'] as String, json['area_description'] as String,
         json['number'] as String, json['reason'] as String);
   }
 
   ///Converts an Outage model to a json object based on the APIs specification.
-  String toJson(Outage outage){
+  String toJson(OutageDto outage){
     Map<String, dynamic> mapOutage = {
       'prefecture' : outage.prefecture,
       'from_datetime' : outage.fromDatetime,

--- a/Client/lib/services/OutagesHandler.dart
+++ b/Client/lib/services/OutagesHandler.dart
@@ -34,18 +34,28 @@ class OutagesHandler {
     bool foundTable = false;
     int ctrRows = 0;
     int ctrMappedValues = 0;
+    String prefecture = "";
     //#endregion
 
     //#region HTML Parsing
     try {
       List<String> data = html.split('\n');
       for (int i = 0; i < data.length; i++) {
+        // Find the selected prefecture. Application does not send request for specific
+        // municipalities (only for prefectures), thus, onl the prefectures table will have
+        // a selected option.
+        if (data[i].contains("option") && data[i].contains("selected")){
+          prefecture = data[i].split('>')[1];
+        }
+        // The table that contains the outages of the selected prefecture.
         if (data[i].contains("tblOutages")) {
           foundTable = true;
         }
+        // Every row of te table contains information about the outage.
         if (data[i].contains("tr") && foundTable) {
           ctrRows++;
         }
+        // Columns of the table contain the specific information, mapped below.
         if (ctrRows > 0 && data[i].contains("td")) {
           List<String> arrVal = data[i].split(">");
           ctrMappedValues++;
@@ -58,6 +68,7 @@ class OutagesHandler {
           if (ctrMappedValues == 7) tempOutage.reason = arrVal[1];
 
           if (ctrMappedValues == 7) {
+            tempOutage.prefecture = prefecture;
             outages.add(tempOutage);
             tempOutage = OutageDto("", "", "", "", "", "", "");
             ctrMappedValues = 0;
@@ -96,6 +107,9 @@ class OutagesHandler {
 
   /// Remove all the known unwanted characters from the passed string.
   static String _normalizeStr(String data){
-    return data.replaceAllMapped("</td", (match) => "");
+    data = data.trim();
+    data = data.replaceAllMapped("</option", (match) => "");
+    data = data.replaceAllMapped("</td", (match) => "");
+    return data;
   }
 }


### PR DESCRIPTION
Included basic logic to determine which prefecture is "selected" and extract it's name from HTML.
When we implement the logic for prefecture selection, this can also be changed (we could not rely to extracting the information from HTML, rather determine the prefecture from the unique prefecture ID passed on the request.