### PR TITLE
Adding Warning widget to warn user that no outages exist for the curr…

### DIFF
--- a/Client/lib/widgets/Screens/Outages.dart
+++ b/Client/lib/widgets/Screens/Outages.dart
@@ -1,3 +1,4 @@
+import 'package:black_out_groutages/widgets/Warning.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart';
 
@@ -84,17 +85,13 @@ class _OutagesScreenState extends State<OutagesScreen> {
     return FutureBuilder(
       future: _getOutages(context),
       builder: (context, snapshot) {
-        // if (snapshot.hasData &&
-        //     snapshot.connectionState == ConnectionState.done) {
-        //   return Scaffold(
-        //       appBar: BaseAppBar(appBar: AppBar()),
-        //       body: Container(child: outagesList(context)),
-        //       bottomNavigationBar: BottomBar(
-        //           selectedIndex: selectedIndex, onClicked: onClicked));
-        // } else {
+        if (snapshot.hasData && snapshot.connectionState == ConnectionState.done) {
+          return Scaffold(
+              body: Container(child: outagesList(context)));
+        } else {
         return Scaffold(
-            body: Container(child: outagesList(context)));
-        //}
+            body: Container(alignment: Alignment.center,child: const Warning(label: "No outages for the selected prefecture")));
+        }
       },
     );
   }

--- a/Client/lib/widgets/Warning.dart
+++ b/Client/lib/widgets/Warning.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+class Warning extends StatelessWidget {
+  final String label;
+
+  const Warning({Key? key, required this.label}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        const Icon(Icons.warning, color: Color(0XFFB00020)),
+        Text(
+          label,
+          style: TextStyle(
+              color: Colors.black.withOpacity(0.6),
+              fontWeight: FontWeight.bold,
+              fontSize: 15),
+        )
+      ],
+    );
+  }
+}


### PR DESCRIPTION
- Added a generic widget that shows a Warning sign along with the provided text.
- On outages screen added a condition: `snapshot.connectionState == done && !snapshot.hasData ` to show the _No Outages for selected Prefecture_ warning.