### PR TITLE
New parser

### DIFF
--- a/Client/lib/services/outages_handler.dart
+++ b/Client/lib/services/outages_handler.dart
@@ -1,6 +1,6 @@
+import 'package:html/dom.dart' as dom;
 import '../../widgets/outage_list_item.dart';
-import 'package:flutter/material.dart';
-
+import 'package:html/parser.dart' show parse;
 import '../models/outage_dto.dart';
 
 /// Includes all the related functions to:
@@ -20,6 +20,47 @@ class OutagesHandler {
       ));
     }
     return outageListItems;
+  }
+
+  /// Parses the HTML response of the outages and looks for the below:
+  /// 1. Table with class "tblOutages".
+  /// 2. If it finds the table, it loops through it's rows.
+  /// 3. For every row, loops through it's columns and stores it's data.
+  ///
+  /// @returns a list of [OutageDto] objects.
+  /// @returns an empty list if no outages found.
+  static List<OutageDto> extract(String html){
+    List<OutageDto> outages = List<OutageDto>.empty(growable: true);
+
+    //#region HTML Parser
+    try{
+      dom.Document document = parse(html);
+      // Find the table that contains the outages of the elected prefecture.
+      dom.Element? tblOutages = document.getElementById("tblOutages");
+      // Find the rows of the table.
+      List<dom.Element> tblRows = tblOutages!.getElementsByTagName("tr");
+      // Navigate through the columns of each row and store the data.
+      for (int i=1; i<tblRows.length; i++){
+        List<dom.Element> tblColumns = tblRows[i].getElementsByTagName("td");
+        OutageDto tmpOutage = OutageDto("", "", "", "", "", "", "");
+        for (int j=0; j<tblColumns.length; j++){
+          String currentValue = tblColumns[j].innerHtml.trim();
+          if (j == 0) tmpOutage.fromDatetime = currentValue;
+          if (j == 1) tmpOutage.toDatetime = currentValue;
+          if (j == 2) tmpOutage.municipality = currentValue;
+          if (j == 3) tmpOutage.areaDescription = currentValue;
+          if (j == 4) tmpOutage.number = currentValue;
+          if (j == 5) tmpOutage.reason = currentValue;
+        }
+        outages.add(tmpOutage);
+      }
+    }
+    catch (e){
+      outages = [];
+    }
+    //#endregion
+
+    return outages;
   }
 
   /// Given an HTML string of a certain structure extracts from it all the outages that can
@@ -42,7 +83,7 @@ class OutagesHandler {
       List<String> data = html.split('\n');
       for (int i = 0; i < data.length; i++) {
         // Find the selected prefecture. Application does not send request for specific
-        // municipalities (only for prefectures), thus, onl the prefectures table will have
+        // municipalities (only for prefectures), thus, only the prefectures table will have
         // a selected option.
         if (data[i].contains("option") && data[i].contains("selected")){
           prefecture = data[i].split('>')[1];

--- a/Client/lib/widgets/screens/outages.dart
+++ b/Client/lib/widgets/screens/outages.dart
@@ -37,7 +37,7 @@ class _OutagesScreenState extends State<OutagesScreen> {
   Future<List<OutageListItem>> _getOutages(BuildContext context) async {
     // perform a request to the configured API
     Response response = (await Rest.doPOST(
-        "https://siteapps.deddie.gr/Outages2Public/?Length=4" "&PrefectureID=23&MunicipalityID=",
+        "https://siteapps.deddie.gr/Outages2Public/?Length=4" "&PrefectureID=10&MunicipalityID=",
         {
           "Accept-Language": "en-US,en;q=0.9,el;q=0.8",
           "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
@@ -50,7 +50,7 @@ class _OutagesScreenState extends State<OutagesScreen> {
     setState(() {
       outageListItems.clear(); // clear the list in order to avoid having duplicate items on reloading
       List<OutageDto> outages = List<OutageDto>.empty(growable: true);
-      outages = OutagesHandler.extractOutages(response.body.toString()); // parse the HTML response and extract outages objects
+      outages = OutagesHandler.extract(response.body.toString()); // parse the HTML response and extract outages objects
       outageListItems = OutagesHandler.getWidgetList(outages); // convert the List<Outage> to List<OutageListItem> in order to be able to display the latter
     });
     return outageListItems;
@@ -86,10 +86,10 @@ class _OutagesScreenState extends State<OutagesScreen> {
     return FutureBuilder(
       future: _getOutages(context),
       builder: (context, snapshot) {
-        if (snapshot.hasData && snapshot.connectionState == ConnectionState.done) {
+        if (snapshot.hasData) {
           return Scaffold(
               body: Container(child: outagesList(context)));
-        } else {
+        } else{
         return Scaffold(
             body: Container(alignment: Alignment.center,child: const Warning(label: "No outages for the selected prefecture")));
         }


### PR DESCRIPTION
The issue with the old parser is that when the `areaDescription` field contains more than one rows it:
- Stores only the first line
- Causes the `reason` field to get the value of the previous field (i.e, `number`).

Created a more concrete constructor that will look for `tblOutages` class and will navigate through each row and it's respective columns, looking for the `innerHtml` of each column.

Also fixed a small bug with `Outages` widget where the `Warning` screen was always shown due to incorrect condition of `ConnectionState`.