### PR TITLE
Deleting persisted outages on default prefecture change

### DIFF
--- a/client/lib/controllers/outages/persisted_outages_strategy.dart
+++ b/client/lib/controllers/outages/persisted_outages_strategy.dart
@@ -14,6 +14,9 @@ class PersistedOutagesControllerStrategy extends BaseOutagesControllerStrategy {
     List<OutageDto> persistedOutagesOfDefaultPrefecture = DataPersistService()
         .getSavedOutages(DataPersistService.outagesOfDefaultPrefecture);
 
+    debugPrint("Selected prefecture: ${selectedPrefecture.name}");
+    debugPrint("Default prefecture: ${defaultPrefecture.name}");
+
     if (selectedPrefecture.name == PrefectureDto.defaultPrefecture().name &&
         persistedOutagesOfDefaultPrefecture.isNotEmpty) {
       debugPrint("Retrieving outages from persistent storage");

--- a/client/lib/services/data_persist.dart
+++ b/client/lib/services/data_persist.dart
@@ -1,4 +1,6 @@
 import 'dart:convert';
+import 'package:flutter/cupertino.dart';
+
 import '../models/outage_dto.dart';
 import '../models/prefecture_dto.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -58,14 +60,17 @@ class DataPersistService {
   PrefectureDto getPrefecture(String key) {
     PrefectureDto prefectureDto = PrefectureDto("23", "ΘΕΣΣΑΛΟΝΙΚΗΣ");
     try {
-      String? data = preferences
-          ?.getString(key); // retrieve the encoded JSON data of the prefecture.
-      Map jsonData =
-          jsonDecode(data!); // decode the saved json data into a Map.
-      prefectureDto = PrefectureDto.fromJson(
-          jsonData); // decode the JSON Map into a PrefectureDto.
+      // retrieve the encoded JSON data of the prefecture.
+      String? data = preferences?.getString(key);
+
+      // decode the saved json data into a Map.
+      Map jsonData = jsonDecode(data!);
+
+      // decode the JSON Map into a PrefectureDto.
+      prefectureDto = PrefectureDto.fromJson(jsonData);
     } catch (e) {
-      //
+      debugPrint(
+          "Failed to get prefecture from persisted storage: ${e.toString()}");
     }
 
     return prefectureDto;
@@ -113,7 +118,8 @@ class DataPersistService {
       String? strSavedOutages = preferences?.getString(key);
       savedOutages = OutageDto.decode(strSavedOutages!);
     } catch (e) {
-      // Swallow the exception
+      debugPrint(
+          "Failed to retrieve the saved outages from persistent storage: ${e.toString()}");
     }
 
     return savedOutages;

--- a/client/lib/widgets/screens/settings.dart
+++ b/client/lib/widgets/screens/settings.dart
@@ -76,6 +76,9 @@ class _SettingsState extends State<Settings> {
                       dataPersistService.persistPrefecture(
                           DataPersistService.defaultPrefecturePreference,
                           value);
+                      // Delete the persisted outages since there is a new default prefecture.
+                      dataPersistService.delete(
+                          DataPersistService.outagesOfDefaultPrefecture);
 
                       setState(() {
                         defaultPrefecture = value;


### PR DESCRIPTION
- Deleting the default outages saved in persisted storage when a new default prefecture is selected (this is in order to refresh the list of outages).
- Code formatting and exception logging.