### PR TITLE
Bug on SOD showing different prefecture / outages

### DIFF
--- a/client/lib/controllers/outages/outages_context.dart
+++ b/client/lib/controllers/outages/outages_context.dart
@@ -15,10 +15,17 @@ import '../../widgets/components/outage_list_item.dart';
 class OutagesContext {
   late OutagesControllerStrategyImpl strategy;
 
+  /// Sets the strategy to be executed.
   void setOutagesStrategy(OutagesControllerStrategyImpl newStrategy) {
     strategy = newStrategy;
   }
 
+  /// Executes the business logic of the controller. This function will
+  /// set the required strategies to be executed. Specifically:
+  /// - Executes the [PersistedOutagesControllerStrategy] in order to retrieve
+  /// any persisted outages.
+  /// - If there aren't any persisted outages, moves on and retrieves the outages
+  /// from the remote source.
   List<OutageListItem> execute(PrefectureDto selectedPrefecture) {
     setOutagesStrategy(PersistedOutagesControllerStrategy());
     strategy.update(selectedPrefecture);

--- a/client/lib/controllers/outages/persisted_outages_strategy.dart
+++ b/client/lib/controllers/outages/persisted_outages_strategy.dart
@@ -17,6 +17,7 @@ class PersistedOutagesControllerStrategy extends OutagesControllerStrategyImpl {
   @override
   Future<List<OutageListItem>> updateOutagesList(
       PrefectureDto selectedPrefecture) async {
+    await OutagesDataPersistService().initializePreferences();
     List<OutageDto> persistedOutagesOfDefaultPrefecture =
         OutagesDataPersistService()
             .retrieveValueOf(DataPersistServiceKeys.outagesOfDefaultPrefecture);

--- a/client/lib/main.dart
+++ b/client/lib/main.dart
@@ -21,14 +21,7 @@ class OutagesApp extends StatelessWidget {
   /// * Sets the default colors and titles to use in case no other colors defined.
   @override
   Widget build(BuildContext context) {
-    // Remove the default outages & notifications from persistent storage.
-    OutagesDataPersistService().initializePreferences();
-    debugPrint("Deleting default prefecture outages persistent storage");
-    OutagesDataPersistService()
-        .delete(DataPersistServiceKeys.outagesOfDefaultPrefecture);
-    OutagesDataPersistService()
-        .delete(DataPersistServiceKeys.notificationOutages);
-
+    initialize();
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'Black Out',
@@ -39,5 +32,16 @@ class OutagesApp extends StatelessWidget {
           scaffoldBackgroundColor: Colors.white),
       home: const Base(title: 'Black Out', key: Key("Black Out")),
     );
+  }
+
+  /// Initializes the preferences and removes the default outages & notifications
+  /// from persistent storage.
+  Future<void> initialize() async {
+    await OutagesDataPersistService().initializePreferences();
+    debugPrint("Deleting default prefecture outages persistent storage");
+    OutagesDataPersistService()
+        .delete(DataPersistServiceKeys.outagesOfDefaultPrefecture);
+    OutagesDataPersistService()
+        .delete(DataPersistServiceKeys.notificationOutages);
   }
 }


### PR DESCRIPTION
Resolving an issue where if the default prefecture is changed and the application restarted, the outages shown do not map to the newly set prefecture.

The root cause of this issue has been identified to be the asynchronous manner of the outages_context.dart, where the retrieval of the default prefecture was not been awaited for.