### PR TITLE
Associating list items with specific keys

### DIFF
--- a/client/lib/widgets/components/outage_list_item.dart
+++ b/client/lib/widgets/components/outage_list_item.dart
@@ -15,7 +15,7 @@ import '../../models/outage_dto.dart';
 class OutageListItem extends StatelessWidget {
   final OutageDto outageDto;
 
-  const OutageListItem({Key? key, required this.outageDto}) : super(key: key);
+  OutageListItem({Key? key, required this.outageDto}) : super(key: ObjectKey(outageDto));
 
   /// Builds the card that shows all the relevant outage information.
   Widget listItem(BuildContext context) {


### PR DESCRIPTION
By having unique keys the framework will sync the entries of the list (where all the outages are displayed) with the corresponding item on the list.

It will also compare the UI diffs more efficiently. If the keys are not unique, and for example the content of the first page of the list scrolls off - flutter tries to match and repaint the layout relying on the first entry of the list, all the way down - which is not efficient at all.